### PR TITLE
Refactor and cleanup import resolving

### DIFF
--- a/contracts/DefaultPaymentHandler.cdc
+++ b/contracts/DefaultPaymentHandler.cdc
@@ -1,6 +1,6 @@
-import PaymentHandler from "./PaymentHandler.cdc"
-import FungibleToken from "./core/FungibleToken.cdc"
-import FungibleTokenSwitchboard from "./core/FungibleTokenSwitchboard.cdc"
+import PaymentHandler from "PaymentHandlerAccount"
+import FungibleToken from "CoreContractsAccount"
+import FungibleTokenSwitchboard from "CoreContractsAccount"
 
 pub contract DefaultPaymentHandler {
 

--- a/contracts/ExampleOfferResolver.cdc
+++ b/contracts/ExampleOfferResolver.cdc
@@ -1,6 +1,6 @@
-import Resolver from "./Resolver.cdc"
-import NonFungibleToken from "./core/NonFungibleToken.cdc"
-import MetadataViews from "./core/MetadataViews.cdc"
+import Resolver from "ResolverAccount"
+import NonFungibleToken from "CoreContractsAccount"
+import MetadataViews from "CoreContractsAccount"
 
 pub contract ExampleOfferResolver {
 

--- a/contracts/Offers.cdc
+++ b/contracts/Offers.cdc
@@ -1,9 +1,9 @@
-import FungibleToken from "./core/FungibleToken.cdc"
-import NonFungibleToken from "./core/NonFungibleToken.cdc"
-import MetadataViews from "./core/MetadataViews.cdc"
-import PaymentHandler from "./PaymentHandler.cdc"
-import DefaultPaymentHandler from "./DefaultPaymentHandler.cdc"
-import Resolver from "./Resolver.cdc"
+import FungibleToken from "CoreContractsAccount"
+import NonFungibleToken from "CoreContractsAccount"
+import MetadataViews from "CoreContractsAccount"
+import PaymentHandler from "PaymentHandlerAccount"
+import DefaultPaymentHandler from "DefaultPaymentHandlerAccount"
+import Resolver from "ResolverAccount"
 
 /// Offers
 ///

--- a/contracts/PaymentHandler.cdc
+++ b/contracts/PaymentHandler.cdc
@@ -1,4 +1,4 @@
-import FungibleToken from "./core/FungibleToken.cdc"
+import FungibleToken from "CoreContractsAccount"
 
 /// PaymentHandler contract
 /// It is generic payment handler, Provides a public interface ,i.e. `PaymentHandlerPublic`

--- a/contracts/Resolver.cdc
+++ b/contracts/Resolver.cdc
@@ -1,5 +1,5 @@
-import NonFungibleToken from "./core/NonFungibleToken.cdc"
-import MetadataViews from "./core/MetadataViews.cdc"
+import NonFungibleToken from "CoreContractsAccount"
+import MetadataViews from "CoreContractsAccount"
 
 pub contract Resolver {
     

--- a/contracts/core/ExampleNFT.cdc
+++ b/contracts/core/ExampleNFT.cdc
@@ -9,8 +9,8 @@
 *   
 */
 
-import NonFungibleToken from "./NonFungibleToken.cdc"
-import MetadataViews from "./MetadataViews.cdc"
+import NonFungibleToken from "CoreContractsAccount"
+import MetadataViews from "CoreContractsAccount"
 
 pub contract ExampleNFT: NonFungibleToken {
 

--- a/contracts/core/ExampleToken.cdc
+++ b/contracts/core/ExampleToken.cdc
@@ -1,4 +1,4 @@
-import FungibleToken from "./FungibleToken.cdc"
+import FungibleToken from "CoreContractsAccount"
 
 pub contract ExampleToken: FungibleToken {
 

--- a/contracts/core/FungibleTokenSwitchboard.cdc
+++ b/contracts/core/FungibleTokenSwitchboard.cdc
@@ -1,4 +1,4 @@
-import FungibleToken from "./FungibleToken.cdc"
+import FungibleToken from "CoreContractsAccount"
 
 /// The contract that allows an account to receive payments in multiple fungible
 /// tokens using a single `{FungibleToken.Receiver}` capability.

--- a/contracts/core/MetadataViews.cdc
+++ b/contracts/core/MetadataViews.cdc
@@ -1,5 +1,5 @@
-import FungibleToken from "./FungibleToken.cdc"
-import NonFungibleToken from "./NonFungibleToken.cdc"
+import FungibleToken from "CoreContractsAccount"
+import NonFungibleToken from "CoreContractsAccount"
 
 /// This contract implements the metadata standard proposed
 /// in FLIP-0636.

--- a/lib/cadence/test/Offers.cdc
+++ b/lib/cadence/test/Offers.cdc
@@ -1,7 +1,7 @@
 import Test
 
 pub var blockchain = Test.newEmulatorBlockchain()
-pub var accounts: {String: Test.Account} = {}
+
 pub enum ErrorType: UInt8 {
     pub case TX_PANIC
     pub case TX_ASSERT
@@ -9,99 +9,48 @@ pub enum ErrorType: UInt8 {
     pub case CONTRACT_WITHDRAWBALANCE
 }
 
+// Setup accounts for the smart contracts.
+pub let coreContractsAccount = blockchain.createAccount()
+
+pub let offers = blockchain.createAccount()
+pub let resolver = blockchain.createAccount()
+pub let offeror = blockchain.createAccount()
+pub let cutReceiver1 = blockchain.createAccount()
+pub let cutReceiver2 = blockchain.createAccount()
+pub let offerAcceptor = blockchain.createAccount()
+pub let royaltyReceiver1 = blockchain.createAccount()
+pub let royaltyReceiver2 = blockchain.createAccount()
+pub let commissionReceiver = blockchain.createAccount()
+pub let paymentHandler = blockchain.createAccount()
+pub let defaultPaymentHandler = blockchain.createAccount()
+pub let testToken = blockchain.createAccount()
+
 pub fun setup() {
 
-    // Setup accounts for the smart contract.
-    let offers = blockchain.createAccount()
-    let resolver = blockchain.createAccount()
-    let exampleOfferResolver = resolver
-    let nft = blockchain.createAccount()
-    let metadataViews = blockchain.createAccount()
-    let fungibleToken = blockchain.createAccount()
-    let nonFungibleToken = blockchain.createAccount()
-    let offeror = blockchain.createAccount()
-    let token = blockchain.createAccount()
-    let cutReceiver1 = blockchain.createAccount()
-    let cutReceiver2 = blockchain.createAccount()
-    let offerAcceptor = blockchain.createAccount()
-    let royaltyReceiver1 = blockchain.createAccount()
-    let royaltyReceiver2 = blockchain.createAccount()
-    let commissionReceiver1 = blockchain.createAccount()
-    let commissionReceiver2 = blockchain.createAccount()
-    let paymentHandler = blockchain.createAccount()
-    let fungibleTokenSwitchboard = blockchain.createAccount()
-    let defaultPaymentHandler = blockchain.createAccount()
-    let testToken = blockchain.createAccount()
-
-
-    accounts = {
-        "FungibleToken": fungibleToken,
-        "NonFungibleToken": nonFungibleToken,
-        "MetadataViews": metadataViews,
-        "ExampleToken": token,
-        "TestToken": testToken,
-        "ExampleNFT": nft,
-        "PaymentHandler": paymentHandler,
-        "FungibleTokenSwitchboard": fungibleTokenSwitchboard,
-        "DefaultPaymentHandler": defaultPaymentHandler,
-        "Resolver": resolver,
-        "ExampleOfferResolver": resolver,
-        "Offers": offers,
-        "offeror": offeror,
-        "offerAcceptor": offerAcceptor,
-        "royaltyReceiver1": royaltyReceiver1,
-        "royaltyReceiver2": royaltyReceiver2,
-        "cutReceiver1": cutReceiver1,
-        "cutReceiver2": cutReceiver2,
-        "CommissionReceiver1": commissionReceiver1,
-        "CommissionReceiver2": commissionReceiver2
-    }
-    
-    // Let the CLI know how the above addresses are mapped to the contracts.
-    blockchain.useConfiguration(Test.Configuration({
-        "./FungibleToken.cdc":accounts["FungibleToken"]!.address,
-        "./NonFungibleToken.cdc":accounts["NonFungibleToken"]!.address,
-        "./MetadataViews.cdc":accounts["MetadataViews"]!.address,
-        "./PaymentHandler.cdc":accounts["PaymentHandler"]!.address,
-        "./DefaultPaymentHandler.cdc":accounts["DefaultPaymentHandler"]!.address,
-        "./core/FungibleToken.cdc":accounts["FungibleToken"]!.address,
-        "./core/NonFungibleToken.cdc":accounts["NonFungibleToken"]!.address,
-        "./core/MetadataViews.cdc":accounts["MetadataViews"]!.address,
-        "./core/FungibleTokenSwitchboard.cdc":accounts["FungibleTokenSwitchboard"]!.address,
-        "./Resolver.cdc":accounts["Resolver"]!.address,
-        "../contracts/PaymentHandler.cdc":accounts["PaymentHandler"]!.address,
-        "../contracts/TestToken.cdc":accounts["TestToken"]!.address,
-        "../contracts/Offers.cdc": accounts["Offers"]!.address,
-        "../contracts/Resolver.cdc": accounts["Resolver"]!.address,
-        "../contracts/ExampleOfferResolver.cdc": accounts["ExampleOfferResolver"]!.address,
-        "../contracts/core/FungibleToken.cdc": accounts["FungibleToken"]!.address,
-        "../contracts/core/NonFungibleToken.cdc": accounts["NonFungibleToken"]!.address,
-        "../contracts/core/ExampleToken.cdc": accounts["ExampleToken"]!.address,
-        "../contracts/core/ExampleNFT.cdc": accounts["ExampleNFT"]!.address,
-        "../contracts/core/MetadataViews.cdc": accounts["MetadataViews"]!.address,
-        "../../../../../contracts/core/FungibleToken.cdc": accounts["FungibleToken"]!.address,
-        "../../../../../contracts/core/ExampleToken.cdc": accounts["ExampleToken"]!.address,
-        "../../../../../contracts/core/MetadataViews.cdc": accounts["MetadataViews"]!.address,
-        "../../../../../contracts/core/NonFungibleToken.cdc": accounts["NonFungibleToken"]!.address,
-        "../../../../../contracts/core/ExampleNFT.cdc": accounts["ExampleNFT"]!.address,
-        "../../../../../contracts/core/FungibleTokenSwitchboard.cdc":accounts["FungibleTokenSwitchboard"]!.address,
-        "../../../../../contracts/Offers.cdc": accounts["Offers"]!.address,
-        "../../contracts/core/NonFungibleToken.cdc": accounts["NonFungibleToken"]!.address,
-        "../../contracts/core/ExampleNFT.cdc": accounts["ExampleNFT"]!.address
+    // Let the CLI know how the above accounts are mapped to the contracts.
+    blockchain.useConfiguration(Test.Configuration(addresses: {
+        "CoreContractsAccount":coreContractsAccount.address,
+        "PaymentHandlerAccount":paymentHandler.address,
+        "DefaultPaymentHandlerAccount":defaultPaymentHandler.address,
+        "ResolverAccount":resolver.address,
+        "ExampleOfferResolverAccount": resolver.address,
+        "PaymentHandlerAccount":paymentHandler.address,
+        "TestTokenAccount":testToken.address,
+        "OffersAccount": offers.address
     }))
 
-    deploySmartContract("FungibleToken", accounts["FungibleToken"]!, "../../../contracts/core/FungibleToken.cdc")
-    deploySmartContract("NonFungibleToken", accounts["NonFungibleToken"]!, "../../../contracts/core/NonFungibleToken.cdc")
-    deploySmartContract("MetadataViews", accounts["MetadataViews"]!, "../../../contracts/core/MetadataViews.cdc")
-    deploySmartContract("ExampleToken", accounts["ExampleToken"]!, "../../../contracts/core/ExampleToken.cdc")
-    deploySmartContract("TestToken", accounts["TestToken"]!, "./mocks/contracts/TestToken.cdc")
-    deploySmartContract("ExampleNFT", accounts["ExampleNFT"]!, "../../../contracts/core/ExampleNFT.cdc")
-    deploySmartContract("FungibleTokenSwitchboard", accounts["FungibleTokenSwitchboard"]!, "../../../contracts/core/FungibleTokenSwitchboard.cdc")
-    deploySmartContract("PaymentHandler", accounts["PaymentHandler"]!, "../../../contracts/PaymentHandler.cdc")
-    deploySmartContract("DefaultPaymentHandler", accounts["DefaultPaymentHandler"]!, "../../../contracts/DefaultPaymentHandler.cdc")
-    deploySmartContract("Resolver", accounts["Resolver"]!, "../../../contracts/Resolver.cdc")
-    deploySmartContract("ExampleOfferResolver", accounts["ExampleOfferResolver"]!, "../../../contracts/ExampleOfferResolver.cdc")
-    deploySmartContract("Offers", accounts["Offers"]!, "../../../contracts/Offers.cdc")
+    deploySmartContract("FungibleToken", coreContractsAccount, "../../../contracts/core/FungibleToken.cdc")
+    deploySmartContract("NonFungibleToken", coreContractsAccount, "../../../contracts/core/NonFungibleToken.cdc")
+    deploySmartContract("MetadataViews", coreContractsAccount, "../../../contracts/core/MetadataViews.cdc")
+    deploySmartContract("ExampleToken", coreContractsAccount, "../../../contracts/core/ExampleToken.cdc")
+    deploySmartContract("FungibleTokenSwitchboard", coreContractsAccount, "../../../contracts/core/FungibleTokenSwitchboard.cdc")
+    deploySmartContract("ExampleNFT", coreContractsAccount, "../../../contracts/core/ExampleNFT.cdc")
+    deploySmartContract("TestToken", testToken, "./mocks/contracts/TestToken.cdc")
+    deploySmartContract("PaymentHandler", paymentHandler, "../../../contracts/PaymentHandler.cdc")
+    deploySmartContract("DefaultPaymentHandler", defaultPaymentHandler, "../../../contracts/DefaultPaymentHandler.cdc")
+    deploySmartContract("Resolver", resolver, "../../../contracts/Resolver.cdc")
+    deploySmartContract("ExampleOfferResolver", resolver, "../../../contracts/ExampleOfferResolver.cdc")
+    deploySmartContract("Offers", offers, "../../../contracts/Offers.cdc")
 }
 
 //////////////
@@ -111,10 +60,10 @@ pub fun setup() {
 
 pub fun testCreateOpenOffers() {
     // Execute transaction
-    executeSetupAccountTx(accounts["offeror"]!)
+    executeSetupAccountTx(offeror)
     // Verify the transaction effects by calling script
     assert(
-        checkAccountHasOpenOffersPublicCapability(accounts["offeror"]!.address),
+        checkAccountHasOpenOffersPublicCapability(offeror.address),
         message: "Given account doesn't hold the OpenOffers resoource"
     )
 }
@@ -137,7 +86,6 @@ pub fun testFailToCreateOfferBecauseAccountDoesNotHaveOpenOffersResource() {
 }
 
 pub fun testFailToCreateOfferBecauseAccountDoesNotHaveNFTReceiverCapability() {
-    let offeror = accounts["offeror"]!
     // Setup Token vault and top up with some tokens
     executeSetupVaultAndMintTokensTx(offeror, 1000.0)
     // Execute createOffer transaction
@@ -158,7 +106,6 @@ pub fun testFailToCreateOfferBecauseAccountDoesNotHaveNFTReceiverCapability() {
 
 
 pub fun testFailToCreateOfferBecauseAccountDoesNotHaveResolverCapability() {
-    let offeror = accounts["offeror"]!
     // Setup NFTReceiver Capability.
     executeSetupExampleNFTAccount(offeror)
     // Execute createOffer transaction
@@ -179,16 +126,15 @@ pub fun testFailToCreateOfferBecauseAccountDoesNotHaveResolverCapability() {
 
 pub fun testSetupResolver() {
     // Execute transaction
-    executeSetupResolverTx(accounts["offeror"]!)
+    executeSetupResolverTx(offeror)
     // Verify the transaction effects by calling script
     assert(
-        checkAccountHasOfferResolverPublicCapability(accounts["offeror"]!.address),
+        checkAccountHasOfferResolverPublicCapability(offeror.address),
         message: "Given account doesn't hold the OpenOffers resoource"
     )
 }
 
 pub fun testFailToCreateOfferBecauseInsufficientOfferAmount() {
-    let offeror = accounts["offeror"]!
     // Execute createOffer transaction
     executeCreateOfferTx(
         offeror,
@@ -206,7 +152,6 @@ pub fun testFailToCreateOfferBecauseInsufficientOfferAmount() {
 }
 
 pub fun testFailToCreateOfferBecauseCommissionReceiverDoesNotHaveCapability() {
-    let offeror = accounts["offeror"]!
     // Execute createOffer transaction
     executeCreateOfferTx(
         offeror,
@@ -217,14 +162,13 @@ pub fun testFailToCreateOfferBecauseCommissionReceiverDoesNotHaveCapability() {
         {"_type": "NFT", "typeId": "Type<@ExampleNFT.NFT>()"},
         offeror.address,
         5.0,
-        [accounts["CommissionReceiver1"]!.address],
+        [commissionReceiver.address],
         "Invalid capability of the commission receiver",
         ErrorType.TX_ASSERT
     )
 }
 
 pub fun testFailToCreateOfferBecauseInsufficientBalance() {
-    let offeror = accounts["offeror"]!
     // Execute createOffer transaction
     executeCreateOfferTx(
         offeror,
@@ -242,16 +186,12 @@ pub fun testFailToCreateOfferBecauseInsufficientBalance() {
 }
 
 pub fun testCreateOffer() {
-    let offeror = accounts["offeror"]!
-    let cutReceiver1 = accounts["cutReceiver1"]!
-    let cutReceiver2 = accounts["cutReceiver2"]!
-    let commissionReceiver1 = accounts["CommissionReceiver1"]!
-    let commissionReceiver2 = accounts["CommissionReceiver2"]!
+    let commissionReceiver2 = blockchain.createAccount()
 
     // Setup the receiver of fungible token
     executeSetupVaultAndMintTokensTx(cutReceiver1, 0.0)
     executeSetupVaultAndMintTokensTx(cutReceiver2, 0.0)
-    executeSetupVaultAndMintTokensTx(commissionReceiver1, 0.0)
+    executeSetupVaultAndMintTokensTx(commissionReceiver, 0.0)
     executeSetupVaultAndMintTokensTx(commissionReceiver2, 0.0)
     // Execute createOffer transaction
     executeCreateOfferTx(
@@ -263,7 +203,7 @@ pub fun testCreateOffer() {
         {"resolver": UInt8(0), "nftId": UInt64(0)},
         offeror.address,
         5.0,
-        [commissionReceiver1.address, commissionReceiver2.address],
+        [commissionReceiver.address, commissionReceiver2.address],
         nil,
         nil
     )
@@ -276,7 +216,6 @@ pub fun testCreateOffer() {
 }
 
 pub fun testGetValidOfferFilterTypes() {
-    let offeror = accounts["offeror"]!
     let offerId = getOfferId(offeror.address, 0)
     let validOfferFilterTypes = getValidOfferFilterTypes(offeror.address, offerId)
     assert(validOfferFilterTypes.length == 3, message: "Incorrect length")
@@ -287,19 +226,13 @@ pub fun testGetValidOfferFilterTypes() {
 }
 
 pub fun testAcceptTheOffer() {
-    let acceptor = accounts["offerAcceptor"]!
-    let offeror = accounts["offeror"]!
-    let royaltyReceiver1 = accounts["royaltyReceiver1"]!
-    let royaltyReceiver2 = accounts["royaltyReceiver2"]!
-    let cutReceiver1 = accounts["cutReceiver1"]!
-    let cutReceiver2 = accounts["cutReceiver2"]!
-    let minter = accounts["ExampleNFT"]!
+    let minter = coreContractsAccount
     let offerId = getOfferId(offeror.address, 0)
 
     // Step 1: Setup the receiver of fungible token
-    executeSetupVaultAndMintTokensTx(acceptor, 0.0)
+    executeSetupVaultAndMintTokensTx(offerAcceptor, 0.0)
     // Step 2: Setup the NFT collection for offer acceptor
-    executeSetupExampleNFTAccount(acceptor)
+    executeSetupExampleNFTAccount(offerAcceptor)
     // Step 3: Mint the NFT and assign the royalties.
     // Step 3a: Setup royalties account
     executeSetupVaultAndSetupRoyaltyReceiver(royaltyReceiver1, /storage/exampleTokenVault)
@@ -307,7 +240,7 @@ pub fun testAcceptTheOffer() {
     // Step 3b: Mint NFT
     executeMintNFTTx(
         minter,
-        acceptor.address,
+        offerAcceptor.address,
         "BasketBall_1",
         "This is first basketball",
         "BASKETBALL",
@@ -318,25 +251,21 @@ pub fun testAcceptTheOffer() {
         nil
     )
 
-    assert(isNFTCompatibleWithOffer(offerId, offeror.address, 0, acceptor.address), message: "NFT is not compabtible with offer filters")
+    assert(isNFTCompatibleWithOffer(offerId, offeror.address, 0, offerAcceptor.address), message: "NFT is not compabtible with offer filters")
 
-    let expectedPaymentToOffree = getExpectedPaymentToOfferee(offerId, offeror.address, acceptor.address, 0, /public/exampleNFTCollection)
+    let expectedPaymentToOffree = getExpectedPaymentToOfferee(offerId, offeror.address, offerAcceptor.address, 0, /public/exampleNFTCollection)
 
     assert(expectedPaymentToOffree == 76.5, message: "Incorrect balance send to acceptor \n Expected 76.5 but got - ".concat(expectedPaymentToOffree.toString()))
 }
 
 pub fun testProvidedNFTShouldNotBeCompatibleWithOffer() {
-    let acceptor = accounts["offerAcceptor"]!
-    let offeror = accounts["offeror"]!
-    let minter = accounts["ExampleNFT"]!
-    let royaltyReceiver1 = accounts["royaltyReceiver1"]!
-    let royaltyReceiver2 = accounts["royaltyReceiver2"]!
+    let minter = coreContractsAccount
     let offerId = getOfferId(offeror.address, 0)
     
     // Step 3b: Mint NFT
     executeMintNFTTx(
         minter,
-        acceptor.address,
+        offerAcceptor.address,
         "BasketBall_1",
         "This is first basketball",
         "BASKETBALL",
@@ -347,19 +276,16 @@ pub fun testProvidedNFTShouldNotBeCompatibleWithOffer() {
         nil
     )
 
-    assert(!isNFTCompatibleWithOffer(offerId, offeror.address, 1, acceptor.address), message: "NFT should not compabtible with offer filters")
+    assert(!isNFTCompatibleWithOffer(offerId, offeror.address, 1, offerAcceptor.address), message: "NFT should not compabtible with offer filters")
 }
 
 pub fun testFailToAcceptOfferBecauseOpenOffersResourceDoesNotExists() {
-    let acceptor = accounts["offerAcceptor"]!
-    let offeror = accounts["offeror"]!
-    let commissionReceiver = accounts["CommissionReceiver1"]!
     let offerId = getOfferId(offeror.address, 0)
     let fakeAccount = blockchain.createAccount()
     
     // It should fail because of OpenOffer doesn't exists
     executeOfferAcceptTx(
-        acceptor,
+        offerAcceptor,
         0,
         offerId,
         fakeAccount.address,
@@ -370,8 +296,6 @@ pub fun testFailToAcceptOfferBecauseOpenOffersResourceDoesNotExists() {
 }
 
 pub fun testFailToAcceptOfferBecauseReceiverCapabilityIsInvalid() {
-    let offeror = accounts["offeror"]!
-    let commissionReceiver = accounts["CommissionReceiver1"]!
     let offerId = getOfferId(offeror.address, 0)
     let fakeReceiver = blockchain.createAccount()
     
@@ -388,15 +312,12 @@ pub fun testFailToAcceptOfferBecauseReceiverCapabilityIsInvalid() {
 }
 
 pub fun testFailToAcceptOfferBecauseCommissionReceiverCapabilityIsInvalid() {
-    let acceptor = accounts["offerAcceptor"]!
-    let offeror = accounts["offeror"]!
-    let commissionReceiver = accounts["CommissionReceiver1"]!
     let offerId = getOfferId(offeror.address, 0)
     let fakeCommissionReceiver = blockchain.createAccount()
     
     // It should fail because of OpenOffer doesn't exists
     executeOfferAcceptTx(
-        acceptor,
+        offerAcceptor,
         0,
         offerId,
         offeror.address,
@@ -407,23 +328,16 @@ pub fun testFailToAcceptOfferBecauseCommissionReceiverCapabilityIsInvalid() {
 }
 
 pub fun testAcceptOfferAndCleanup() {
-    let acceptor = accounts["offerAcceptor"]!
-    let offeror = accounts["offeror"]!
-    let royaltyReceiver1 = accounts["royaltyReceiver1"]!
-    let royaltyReceiver2 = accounts["royaltyReceiver2"]!
-    let cutReceiver1 = accounts["cutReceiver1"]!
-    let cutReceiver2 = accounts["cutReceiver2"]!
-    let minter = accounts["ExampleNFT"]!
-    let commissionReceiver1 = accounts["CommissionReceiver1"]!
+    let minter = coreContractsAccount
     let offerId = getOfferId(offeror.address, 0)
 
     // Execute accept transaction
     executeOfferAcceptTx(
-        acceptor,
+        offerAcceptor,
         0,
         offerId,
         offeror.address,
-        commissionReceiver1.address,
+        commissionReceiver.address,
         nil,
         nil
     )
@@ -437,8 +351,8 @@ pub fun testAcceptOfferAndCleanup() {
         message: "Incorrect balance send to royalty receiver 2 \n Expected 25.0 but got - ".concat((getBalance(royaltyReceiver2.address)).toString())
     )
     assert(
-        getBalance(acceptor.address) == 76.5,
-        message: "Incorrect balance send to acceptor \n Expected 87.5 but got - ".concat((getBalance(acceptor.address)).toString())
+        getBalance(offerAcceptor.address) == 76.5,
+        message: "Incorrect balance send to acceptor \n Expected 87.5 but got - ".concat((getBalance(offerAcceptor.address)).toString())
     )
     assert(
         getBalance(cutReceiver1.address) == 12.0,
@@ -449,8 +363,8 @@ pub fun testAcceptOfferAndCleanup() {
         message: "Incorrect balance send to cut receiver 1 \n Expected 13.0 but got - ".concat((getBalance(cutReceiver2.address)).toString())
     )
     assert(
-        getBalance(commissionReceiver1.address) == 5.0,
-        message: "Incorrect balance send to commission receiver 1 \n Expected 5.0 but got - ".concat((getBalance(commissionReceiver1.address)).toString())
+        getBalance(commissionReceiver.address) == 5.0,
+        message: "Incorrect balance send to commission receiver 1 \n Expected 5.0 but got - ".concat((getBalance(commissionReceiver.address)).toString())
     )
     assert(
         getLatestCollectionId(offeror.address, /public/exampleNFTCollection) == 0,
@@ -459,14 +373,7 @@ pub fun testAcceptOfferAndCleanup() {
 }
 
 pub fun testGhostListingScenario() {
-    let acceptor = accounts["offerAcceptor"]!
-    let offeror = accounts["offeror"]!
-    let royaltyReceiver1 = accounts["royaltyReceiver1"]!
-    let royaltyReceiver2 = accounts["royaltyReceiver2"]!
-    let cutReceiver1 = accounts["cutReceiver1"]!
-    let cutReceiver2 = accounts["cutReceiver2"]!
-    let minter = accounts["ExampleNFT"]!
-    let commissionReceiver1 = accounts["CommissionReceiver1"]!
+    let minter = coreContractsAccount
     let unknownReceiver = blockchain.createAccount()
 
     // Execute createOffer transaction
@@ -479,7 +386,7 @@ pub fun testGhostListingScenario() {
         {"resolver": UInt8(0), "nftId": UInt64(2)},
         offeror.address,
         5.0,
-        [commissionReceiver1.address],
+        [commissionReceiver.address],
         nil,
         nil
     )
@@ -505,14 +412,9 @@ pub fun testGhostListingScenario() {
 }
 
 pub fun testPaymentAccurementWhenCapabilityTypeDiffersAndCommissionIsGrabForAnyone() {
-    let acceptor = accounts["offerAcceptor"]!
-    let offeror = accounts["offeror"]!
     let royaltyRecv1 = blockchain.createAccount()
     let royaltyRecv2 = blockchain.createAccount()
-    let cutReceiver1 = accounts["cutReceiver1"]!
-    let cutReceiver2 = accounts["cutReceiver2"]!
-    let minter = accounts["ExampleNFT"]!
-    let commissionReceiver1 = accounts["CommissionReceiver1"]!
+    let minter = coreContractsAccount
     let unknownReceiver = blockchain.createAccount()
 
     // Execute createOffer transaction
@@ -554,7 +456,7 @@ pub fun testPaymentAccurementWhenCapabilityTypeDiffersAndCommissionIsGrabForAnyo
     // Step 3.a: Mint NFT
     executeMintNFTTx(
         minter,
-        acceptor.address,
+        offerAcceptor.address,
         "BasketBall_4",
         "This is first basketball",
         "BASKETBALL",
@@ -565,20 +467,20 @@ pub fun testPaymentAccurementWhenCapabilityTypeDiffersAndCommissionIsGrabForAnyo
         nil
     )
 
-    assert(isNFTCompatibleWithOffer(offerId, offeror.address, 2, acceptor.address), message: "NFT should not compabtible with offer filters")
+    assert(isNFTCompatibleWithOffer(offerId, offeror.address, 2, offerAcceptor.address), message: "NFT should not compabtible with offer filters")
 
     // Execute accept transaction
     executeOfferAcceptTx(
-        acceptor,
+        offerAcceptor,
         2,
         offerId,
         offeror.address,
-        commissionReceiver1.address,
+        commissionReceiver.address,
         nil,
         nil
     )
 
-    assert(checkReceiverCapabilityConformPaymentHandler(royaltyRecv1.address, /public/GenericFTReceiver, accounts["Offers"]!.address), message: "Should be true")
+    assert(checkReceiverCapabilityConformPaymentHandler(royaltyRecv1.address, /public/GenericFTReceiver, offers.address), message: "Should be true")
 
     assert(
         getBalance(royaltyRecv1.address) == 14.5,
@@ -586,8 +488,8 @@ pub fun testPaymentAccurementWhenCapabilityTypeDiffersAndCommissionIsGrabForAnyo
     )
     // royaltyRecv2 wouldn't get any funds and funds allocated to it transferred to acceptor i.e. 29.0
     assert(
-        getBalance(acceptor.address) == 76.5 + 29.0 + 76.5,  // 76.5 would be its existing balance
-        message: "Incorrect balance send to acceptor \n Expected 182.0 but got - ".concat((getBalance(acceptor.address)).toString())
+        getBalance(offerAcceptor.address) == 76.5 + 29.0 + 76.5,  // 76.5 would be its existing balance
+        message: "Incorrect balance send to acceptor \n Expected 182.0 but got - ".concat((getBalance(offerAcceptor.address)).toString())
     )
     assert(
         getBalance(cutReceiver1.address) == 12.0 + 12.0, // 12.0 would be its existing balance
@@ -598,8 +500,8 @@ pub fun testPaymentAccurementWhenCapabilityTypeDiffersAndCommissionIsGrabForAnyo
         message: "Incorrect balance send to cut receiver 1 \n Expected 26.0 but got - ".concat((getBalance(cutReceiver2.address)).toString())
     )
     assert(
-        getBalance(commissionReceiver1.address) == 5.0 + 5.0, // 10.0 would be its existing balance
-        message: "Incorrect balance send to commission receiver 1 \n Expected 10.0 but got - ".concat((getBalance(commissionReceiver1.address)).toString())
+        getBalance(commissionReceiver.address) == 5.0 + 5.0, // 10.0 would be its existing balance
+        message: "Incorrect balance send to commission receiver 1 \n Expected 10.0 but got - ".concat((getBalance(commissionReceiver.address)).toString())
     )
     assert(
         getLatestCollectionId(offeror.address, /public/exampleNFTCollection) == 0,
@@ -758,7 +660,7 @@ pub fun executeSetupVaultForTestTokenAndSetupRoyaltyReceiver(_ whom: Test.Accoun
 pub fun mintTokens(_ recipient: Address, _ amount: UFix64) {
     let txCode = Test.readFile("./mocks/transactions/mint_tokens.cdc")
     assert(
-        txExecutor(txCode, [accounts["ExampleToken"]!], [recipient, amount], nil, nil),
+        txExecutor(txCode, [coreContractsAccount], [recipient, amount], nil, nil),
         message: "Failed to mint tokens to given recipient"
     )
 }

--- a/lib/cadence/test/mocks/contracts/TestToken.cdc
+++ b/lib/cadence/test/mocks/contracts/TestToken.cdc
@@ -1,4 +1,4 @@
-import FungibleToken from "../../../../../contracts/core/FungibleToken.cdc"
+import FungibleToken from "CoreContractsAccount"
 
 pub contract TestToken: FungibleToken {
 

--- a/lib/cadence/test/mocks/scripts/get_collection_ids.cdc
+++ b/lib/cadence/test/mocks/scripts/get_collection_ids.cdc
@@ -1,5 +1,5 @@
-import NonFungibleToken from "../../../../../contracts/core/NonFungibleToken.cdc"
-import ExampleNFT from "../../../../../contracts/core/ExampleNFT.cdc"
+import NonFungibleToken from "CoreContractsAccount"
+import ExampleNFT from "CoreContractsAccount"
 
 /// Script to get NFT IDs in an account's collection
 ///

--- a/lib/cadence/test/mocks/scripts/get_collection_ids_length.cdc
+++ b/lib/cadence/test/mocks/scripts/get_collection_ids_length.cdc
@@ -1,5 +1,5 @@
-import NonFungibleToken from "../../../../../contracts/core/NonFungibleToken.cdc"
-import ExampleNFT from "../../../../../contracts/core/ExampleNFT.cdc"
+import NonFungibleToken from "CoreContractsAccount"
+import ExampleNFT from "CoreContractsAccount"
 
 /// Script to get NFT IDs in an account's collection
 ///

--- a/lib/cadence/test/mocks/scripts/get_offer_cuts.cdc
+++ b/lib/cadence/test/mocks/scripts/get_offer_cuts.cdc
@@ -1,6 +1,6 @@
-import Offers from "../../../../../contracts/Offers.cdc"
-import FungibleToken from "../../../../../contracts/core/FungibleToken.cdc"
-import ExampleToken from "../../../../../contracts/core/ExampleToken.cdc"
+import Offers from "OffersAccount"
+import FungibleToken from "CoreContractsAccount"
+import ExampleToken from "CoreContractsAccount"
 
 pub fun main(receivers: [Address], amounts: [UFix64]): [Offers.OfferCut] {
     var cuts : [Offers.OfferCut] = []

--- a/lib/cadence/test/mocks/scripts/get_offer_details.cdc
+++ b/lib/cadence/test/mocks/scripts/get_offer_details.cdc
@@ -1,4 +1,4 @@
-import Offers from "../../../../../contracts/Offers.cdc"
+import Offers from "OffersAccount"
 
 // This script returns the details for a Offer within a OpenOffer
 

--- a/lib/cadence/test/mocks/scripts/get_offer_ids_at_index.cdc
+++ b/lib/cadence/test/mocks/scripts/get_offer_ids_at_index.cdc
@@ -1,4 +1,4 @@
-import Offers from "../../../../../contracts/Offers.cdc"
+import Offers from "OffersAccount"
 
 // This script returns an array of all the offers created under given account owned OpenOffers resource
 // TEST-FRAMEWORK: Because of the cadence test incompetency.

--- a/lib/cadence/test/mocks/scripts/get_offer_ids_length.cdc
+++ b/lib/cadence/test/mocks/scripts/get_offer_ids_length.cdc
@@ -1,4 +1,4 @@
-import Offers from "../../../../../contracts/Offers.cdc"
+import Offers from "OffersAccount"
 
 // This script returns an array of all the offers created under given account owned OpenOffers resource
 // TEST-FRAMEWORK: Because of the cadence test incompetency.

--- a/lib/cadence/test/mocks/scripts/get_type_of_example_nft.cdc
+++ b/lib/cadence/test/mocks/scripts/get_type_of_example_nft.cdc
@@ -1,4 +1,4 @@
-import ExampleNFT from "../../../../../contracts/core/ExampleNFT.cdc"
+import ExampleNFT from "CoreContractsAccount"
 
 pub fun main(): Type {
     return Type<@ExampleNFT.NFT>()

--- a/lib/cadence/test/mocks/scripts/get_vault_balance.cdc
+++ b/lib/cadence/test/mocks/scripts/get_vault_balance.cdc
@@ -1,6 +1,6 @@
 // This script reads the balance field of an account's ExampleToken Balance
-import FungibleToken from "../../../../../contracts/core/FungibleToken.cdc"
-import ExampleToken from "../../../../../contracts/core/ExampleToken.cdc"
+import FungibleToken from "CoreContractsAccount"
+import ExampleToken from "CoreContractsAccount"
 
 pub fun main(account: Address): UFix64 {
     let acct = getAccount(account)

--- a/lib/cadence/test/mocks/transactions/mint_nft.cdc
+++ b/lib/cadence/test/mocks/transactions/mint_nft.cdc
@@ -1,7 +1,7 @@
-import NonFungibleToken from "../../../../../contracts/core/NonFungibleToken.cdc"
-import ExampleNFT from "../../../../../contracts/core/ExampleNFT.cdc"
-import MetadataViews from "../../../../../contracts/core/MetadataViews.cdc"
-import FungibleToken from "../../../../../contracts/core/FungibleToken.cdc"
+import NonFungibleToken from "CoreContractsAccount"
+import ExampleNFT from "CoreContractsAccount"
+import MetadataViews from "CoreContractsAccount"
+import FungibleToken from "CoreContractsAccount"
 
 /// This script uses the NFTMinter resource to mint a new NFT
 /// It must be run with the account that has the minter resource

--- a/lib/cadence/test/mocks/transactions/mint_tokens.cdc
+++ b/lib/cadence/test/mocks/transactions/mint_tokens.cdc
@@ -1,5 +1,5 @@
-import FungibleToken from "../../../../../contracts/core/FungibleToken.cdc"
-import ExampleToken from "../../../../../contracts/core/ExampleToken.cdc"
+import FungibleToken from "CoreContractsAccount"
+import ExampleToken from "CoreContractsAccount"
 
 /// This transaction is what the minter Account uses to mint new tokens
 /// They provide the recipient address and amount to mint, and the tokens

--- a/lib/cadence/test/mocks/transactions/setup_account_to_receive_royalty.cdc
+++ b/lib/cadence/test/mocks/transactions/setup_account_to_receive_royalty.cdc
@@ -9,8 +9,8 @@
 /// The path used for the public link is a new path that in the future, is expected to receive
 /// and generic token, which could be forwarded to the appropriate vault
 
-import FungibleToken from "../../../../../contracts/core/FungibleToken.cdc"
-import MetadataViews from "../../../../../contracts/core/MetadataViews.cdc"
+import FungibleToken from "CoreContractsAccount"
+import MetadataViews from "CoreContractsAccount"
 
 transaction(vaultPath: StoragePath) {
 

--- a/lib/cadence/test/mocks/transactions/setup_example_nft_account.cdc
+++ b/lib/cadence/test/mocks/transactions/setup_example_nft_account.cdc
@@ -1,6 +1,6 @@
-import NonFungibleToken from "../../../../../contracts/core/NonFungibleToken.cdc"
-import ExampleNFT from "../../../../../contracts/core/ExampleNFT.cdc"
-import MetadataViews from "../../../../../contracts/core/MetadataViews.cdc"
+import NonFungibleToken from "CoreContractsAccount"
+import ExampleNFT from "CoreContractsAccount"
+import MetadataViews from "CoreContractsAccount"
 
 /// This transaction is what an account would run
 /// to set itself up to receive NFTs

--- a/lib/cadence/test/mocks/transactions/setup_example_token_account.cdc
+++ b/lib/cadence/test/mocks/transactions/setup_example_token_account.cdc
@@ -2,9 +2,9 @@
 // anyone to add a Vault resource to their account so that 
 // they can use the exampleToken
 
-import FungibleToken from "../../../../../contracts/core/FungibleToken.cdc"
-import ExampleToken from "../../../../../contracts/core/ExampleToken.cdc"
-import TestToken from "../contracts/TestToken.cdc"
+import FungibleToken from "CoreContractsAccount"
+import ExampleToken from "CoreContractsAccount"
+import TestToken from "TestTokenAccount"
 
 transaction(tokenType: UInt8) {
 

--- a/lib/cadence/test/mocks/transactions/setup_switchboard_to_account_to_receive_royalty.cdc
+++ b/lib/cadence/test/mocks/transactions/setup_switchboard_to_account_to_receive_royalty.cdc
@@ -3,9 +3,9 @@
 /// to create a new link in their account to be used for receiving royalties
 /// This transaction can be used for any fungible token, which is specified by the `vaultPath` argument
 /// 
-import FungibleToken from "../../../../../contracts/core/FungibleToken.cdc"
-import MetadataViews from "../../../../../contracts/core/MetadataViews.cdc"
-import FungibleTokenSwitchboard from "../../../../../contracts/core/FungibleTokenSwitchboard.cdc"
+import FungibleToken from "CoreContractsAccount"
+import MetadataViews from "CoreContractsAccount"
+import FungibleTokenSwitchboard from "CoreContractsAccount"
 
 transaction(vaultPath: StoragePath, receiverPath: PublicPath) {
 

--- a/lib/cadence/test/mocks/transactions/transfer_funds_using_private_capability.cdc
+++ b/lib/cadence/test/mocks/transactions/transfer_funds_using_private_capability.cdc
@@ -5,9 +5,9 @@
 // The withdraw amount and the account from getAccount
 // would be the parameters to the transaction
 
-import FungibleToken from "../../../../../contracts/core/FungibleToken.cdc"
-import ExampleToken from "../../../../../contracts/core/ExampleToken.cdc"
-import Offers from "../../../../../contracts/Offers.cdc"
+import FungibleToken from "CoreContractsAccount"
+import ExampleToken from "CoreContractsAccount"
+import Offers from "OffersAccount"
 
 transaction(amount: UFix64, to: Address) {
 

--- a/lib/cadence/test/mocks/transactions/transfer_tokens.cdc
+++ b/lib/cadence/test/mocks/transactions/transfer_tokens.cdc
@@ -5,8 +5,8 @@
 // The withdraw amount and the account from getAccount
 // would be the parameters to the transaction
 
-import FungibleToken from "../../../../../contracts/core/FungibleToken.cdc"
-import ExampleToken from "../../../../../contracts/core/ExampleToken.cdc"
+import FungibleToken from "CoreContractsAccount"
+import ExampleToken from "CoreContractsAccount"
 
 transaction(amount: UFix64, to: Address) {
 

--- a/scripts/check_offer_matches_with_nft.cdc
+++ b/scripts/check_offer_matches_with_nft.cdc
@@ -1,7 +1,7 @@
-import Offers from "../contracts/Offers.cdc"
-import NonFungibleToken from "../contracts/core/NonFungibleToken.cdc"
-import MetadataViews from "../contracts/core/MetadataViews.cdc"
-import ExampleNFT from "../contracts/core/ExampleNFT.cdc"
+import Offers from "OffersAccount"
+import NonFungibleToken from "CoreContractsAccount"
+import MetadataViews from "CoreContractsAccount"
+import ExampleNFT from "CoreContractsAccount"
 
 pub fun main(offerId: UInt64, offerCreator: Address, nftId: UInt64, nftAccountOwner: Address): Bool {
     let nftCollectionRef = getAccount(nftAccountOwner)

--- a/scripts/check_offer_resolver_public_capability_exists.cdc
+++ b/scripts/check_offer_resolver_public_capability_exists.cdc
@@ -1,5 +1,5 @@
-import Resolver from "../contracts/Resolver.cdc"
-import ExampleOfferResolver from "../contracts/ExampleOfferResolver.cdc"
+import Resolver from "ResolverAccount"
+import ExampleOfferResolver from "ExampleOfferResolverAccount"
 
 pub fun main(target: Address): Bool {
     let capRef = getAccount(target).getCapability<&ExampleOfferResolver.OfferResolver{Resolver.ResolverPublic}>(

--- a/scripts/check_open_offers_public_capability_exists.cdc
+++ b/scripts/check_open_offers_public_capability_exists.cdc
@@ -1,4 +1,4 @@
-import Offers from "../contracts/Offers.cdc"
+import Offers from "OffersAccount"
 
 pub fun main(target: Address): Bool {
     let capRef = getAccount(target).getCapability<&Offers.OpenOffers{Offers.OpenOffersPublic}>(

--- a/scripts/check_receiver_capability_conforms_payment_handler.cdc
+++ b/scripts/check_receiver_capability_conforms_payment_handler.cdc
@@ -1,6 +1,6 @@
-import PaymentHandler from "../contracts/PaymentHandler.cdc"
-import FungibleToken from "../contracts/core/FungibleToken.cdc"
-import ExampleToken from "../contracts/core/ExampleToken.cdc"
+import PaymentHandler from "PaymentHandlerAccount"
+import FungibleToken from "CoreContractsAccount"
+import ExampleToken from "CoreContractsAccount"
 
 pub fun main(receiver: Address, receiverPath: PublicPath, defaultPaymentHandlerOwner: Address): Bool {
     let paymentHandlerRef = getAccount(defaultPaymentHandlerOwner)

--- a/scripts/get_expected_payment_to_offeree.cdc
+++ b/scripts/get_expected_payment_to_offeree.cdc
@@ -1,6 +1,6 @@
-import Offers from "../contracts/Offers.cdc"
-import NonFungibleToken from "../contracts/core/NonFungibleToken.cdc"
-import MetadataViews from "../contracts/core/MetadataViews.cdc"
+import Offers from "OffersAccount"
+import NonFungibleToken from "CoreContractsAccount"
+import MetadataViews from "CoreContractsAccount"
 
 /// It allows to tell how much amount that offeree receives if it accepts offer of offeror
 pub fun main(offerId: UInt64, offerCreator: Address, offereeAddress: Address, nftId: UInt64, collectionPublicPath: PublicPath): UFix64 {

--- a/scripts/get_offer_details.cdc
+++ b/scripts/get_offer_details.cdc
@@ -1,4 +1,4 @@
-import Offers from "../contracts/Offers.cdc"
+import Offers from "OffersAccount"
 
 /// This script returns the details for a Offer within a OpenOffer
 pub fun main(account: Address, offerId: UInt64): Offers.OfferDetails {

--- a/scripts/get_offer_ids.cdc
+++ b/scripts/get_offer_ids.cdc
@@ -1,4 +1,4 @@
-import Offers from "../contracts/Offers.cdc"
+import Offers from "OffersAccount"
 
 /// This script returns an array of all the offers created under given account owned OpenOffers resource
 pub fun main(account: Address): [UInt64] {

--- a/scripts/get_valid_offer_filter_types.cdc
+++ b/scripts/get_valid_offer_filter_types.cdc
@@ -1,4 +1,4 @@
-import Offers from "../contracts/Offers.cdc"
+import Offers from "OffersAccount"
 
 /// This script returns an array of all the offers created under given account owned OpenOffers resource
 pub fun main(account: Address, offerId: UInt64): {String: String} {

--- a/transactions/accept_offer.cdc
+++ b/transactions/accept_offer.cdc
@@ -1,8 +1,8 @@
-import Offers from "../contracts/Offers.cdc"
-import FungibleToken from "../contracts/core/FungibleToken.cdc"
-import NonFungibleToken from "../contracts/core/NonFungibleToken.cdc"
-import ExampleToken from "../contracts/core/ExampleToken.cdc"
-import ExampleNFT from "../contracts/core/ExampleNFT.cdc"
+import Offers from "OffersAccount"
+import FungibleToken from "CoreContractsAccount"
+import NonFungibleToken from "CoreContractsAccount"
+import ExampleToken from "CoreContractsAccount"
+import ExampleNFT from "CoreContractsAccount"
 
 transaction(nftId: UInt64, offerId: UInt64, openOffersHolder: Address, commissionReceiver: Address) {
 

--- a/transactions/accept_offer_and_cleanup.cdc
+++ b/transactions/accept_offer_and_cleanup.cdc
@@ -1,8 +1,8 @@
-import Offers from "../contracts/Offers.cdc"
-import FungibleToken from "../contracts/core/FungibleToken.cdc"
-import NonFungibleToken from "../contracts/core/NonFungibleToken.cdc"
-import ExampleToken from "../contracts/core/ExampleToken.cdc"
-import ExampleNFT from "../contracts/core/ExampleNFT.cdc"
+import Offers from "OffersAccount"
+import FungibleToken from "CoreContractsAccount"
+import NonFungibleToken from "CoreContractsAccount"
+import ExampleToken from "CoreContractsAccount"
+import ExampleNFT from "CoreContractsAccount"
 
 transaction(nftId: UInt64, offerId: UInt64, openOffersHolder: Address, commissionReceiver: Address) {
 

--- a/transactions/cleanup_ghost_offer.cdc
+++ b/transactions/cleanup_ghost_offer.cdc
@@ -1,4 +1,4 @@
-import Offers from "../contracts/Offers.cdc"
+import Offers from "OffersAccount"
 
 transaction(offerId: UInt64, openOfferOwner: Address) {
 

--- a/transactions/propose_offer.cdc
+++ b/transactions/propose_offer.cdc
@@ -1,9 +1,9 @@
-import Offers from "../contracts/Offers.cdc"
-import Resolver from "../contracts/Resolver.cdc"
-import FungibleToken from "../contracts/core/FungibleToken.cdc"
-import NonFungibleToken from "../contracts/core/NonFungibleToken.cdc"
-import ExampleToken from "../contracts/core/ExampleToken.cdc"
-import ExampleNFT from "../contracts/core/ExampleNFT.cdc"
+import Offers from "OffersAccount"
+import Resolver from "ResolverAccount"
+import FungibleToken from "CoreContractsAccount"
+import NonFungibleToken from "CoreContractsAccount"
+import ExampleToken from "CoreContractsAccount"
+import ExampleNFT from "CoreContractsAccount"
 
 /// This version of transaction is implemented because cadence test framework doesn't support importing of contract.
 transaction(

--- a/transactions/remove_offer.cdc
+++ b/transactions/remove_offer.cdc
@@ -1,4 +1,4 @@
-import Offers from "../contracts/Offers.cdc"
+import Offers from "OffersAccount"
 
 transaction(offerId: UInt64) {
     let offerManager: &Offers.OpenOffers{Offers.OfferManager}

--- a/transactions/setup_account.cdc
+++ b/transactions/setup_account.cdc
@@ -1,4 +1,4 @@
-import Offers from "../contracts/Offers.cdc"
+import Offers from "OffersAccount"
 
 /// This transaction installs the OpenOffers ressource in an account.
 

--- a/transactions/setup_resolver.cdc
+++ b/transactions/setup_resolver.cdc
@@ -1,5 +1,5 @@
-import Resolver from "../contracts/Resolver.cdc"
-import ExampleOfferResolver from "../contracts/ExampleOfferResolver.cdc"
+import Resolver from "ResolverAccount"
+import ExampleOfferResolver from "ExampleOfferResolverAccount"
 
 /// This transaction installs the OfferResolver ressource in an account.
 transaction {


### PR DESCRIPTION
Noticed that the import address resolving can be simplified quite a bit. Import location only needs to be a placeholder, doesn't need to be the file path. (https://developers.flow.com/cadence/testing-framework#configuring-import-addresses)

I think other commands of CLI also now support the same format: https://github.com/onflow/flow-cli/issues/711

Also bundled all core contracts into one account during tests (`CoreContractsAccount`)

**IMPORTANT**: 
I only updated what is used by tests. Might need to also update `flow.json` with the contracts name-to-source mapping and account name-to-address mapping as mentioned in https://github.com/onflow/flow-cli/issues/711, to make deployments work properly.
