### PR TITLE
Add coverage support in the test bash script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install Flow CLI
-      run: sh -ci "$(curl -fsSL https://raw.githubusercontent.com/onflow/flow-cli/master/install.sh)" -- v0.44.0
+      run: sh -ci "$(curl -fsSL https://raw.githubusercontent.com/onflow/flow-cli/master/install.sh)" -- v1.0.2
     - name: Flow cli Version
       run: flow version
     - name: Update PATH

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
 
-flow test -l "info,error" ./lib/cadence/test/Offers.cdc
+flow test --cover -l "info,error" ./lib/cadence/test/Offers.cdc


### PR DESCRIPTION
- Update the CI workflow to use the `v1.0.2` flow-cli version
- Update the `test.sh` bash script to enable coverage support